### PR TITLE
bump version to 010 and make it snapshot, and rename container to engine-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This project contains entities and other items for using Apache Brooklyn in a co
 So far this includes:
 
 * `docker-engine` for provisioning a VM with Docker hosts; normal `SoftwareProcess` configuration keys apply
-* `docker-container` for provisioning a container within a `docker-engine`, 
-  using the key `container` for the image name at Docker Hub,
+* `docker-engine-container` for provisioning a container on a `docker-engine`, as a child of that node,
+  using the key `container` for the image name at Docker Hub
   and optionally using `postLaunchCommand` (from `SoftwareProcess`) for any additional commands e.g. port-forwards
 
 Here's an example:
@@ -16,7 +16,7 @@ Here's an example:
 services:
 - type: docker-engine
   brooklyn.children:
-  - type: docker-container
+  - type: docker-engine-container
     container: hello-world
 ```
 

--- a/catalog.bom
+++ b/catalog.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: 0.0.3
+  version: 0.1.0_SNAPSHOT
   iconUrl: https://raw.githubusercontent.com/docker-library/docs/c350af05d3fac7b5c3f6327ac82fe4d990d8729c/docker/logo.png
 
   publish:
@@ -38,8 +38,8 @@ brooklyn.catalog:
       # ensure docker running before starting children
       childStartMode: foreground_late
 
-  - id: docker-container
-    description: An easy way to launch a Docker container
+  - id: docker-engine-container
+    description: An easy way to launch a Docker container, as a child of a docker-engine entity
     itemType: entity
     item:
       type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess


### PR DESCRIPTION
calling it `docker-engine-container` reinforces that this is for making a container once we have deployed a docker host.  this is to distinguish it from other future approaches viz using `jclouds:docker` and specifying the docker image in that API.