### PR TITLE
Remove login user

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -34,7 +34,6 @@ brooklyn.catalog:
 
       provisioning.properties:
         osFamily: centos
-        loginUser: centos
       # ensure docker running before starting children
       childStartMode: foreground_late
 


### PR DESCRIPTION
The blueprint would fail until `loginUser` was removed -- after the machine was provisioned, Brooklyn could not SSH into the machine.